### PR TITLE
feat: add lucide-react dependency and refactor WorkflowDiagram component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "marketing",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.544.0",
         "next": "15.5.2",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -4193,6 +4194,14 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "lucide-react": "^0.544.0",
+    "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/components/WorkflowDiagram.tsx
+++ b/src/app/components/WorkflowDiagram.tsx
@@ -1,110 +1,61 @@
-import Image from "next/image";
+import { FileSearch, BarChart3, PenTool, BookOpen } from "lucide-react";
+
+const steps = [
+  {
+    key: "research",
+    label: "Research Agent",
+    icon: <FileSearch size={28} className="text-white" />,
+    textClass: "text-white",
+    bgClass: "bg-black/70",
+  },
+  {
+    key: "analysis",
+    label: "Analysis Agent",
+    icon: <BarChart3 size={28} className="text-cyan-300" />,
+    textClass: "text-cyan-300",
+    bgClass: "bg-black/70",
+  },
+  {
+    key: "writing",
+    label: "Writing Agent",
+    icon: <PenTool size={28} className="text-pink-400" />,
+    textClass: "text-pink-400",
+    bgClass: "bg-black/70",
+  },
+  {
+    key: "content",
+    label: "Expert Content",
+    icon: <BookOpen size={28} className="text-purple-300" />,
+    textClass: "text-purple-300",
+    bgClass: "bg-black/70",
+  },
+];
+
+const arrows = ["text-purple-400", "text-cyan-300", "text-pink-400"];
 
 export default function WorkflowDiagram() {
   return (
-    <div className="w-full flex flex-col items-center py-1 px-2">
-      <div
-        className="flex flex-row items-center justify-center gap-6 bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl p-6 shadow-xl relative overflow-hidden"
-        style={{ minHeight: 250 }}
-      >
-        {/* Research Agent */}
-        <div className="flex flex-col items-center">
-          <div className="bg-black/60 rounded-xl p-4 flex flex-col items-center shadow-lg">
-            <span className="text-4xl mb-2" role="img" aria-label="brain">
-              <Image
-                src="/file.svg"
-                alt="Research Agent"
-                width={40}
-                height={40}
-                className="mb-2"
-                style={{
-                  filter:
-                    "invert(60%) sepia(80%) saturate(500%) hue-rotate(230deg)",
-                }}
-              />
-            </span>
-            <span className="text-sm font-semibold text-white">
-              Research Agent
-            </span>
+    <div className="w-full flex flex-col items-center py-6 px-4">
+      <div className="flex flex-row items-center justify-center gap-8 bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl p-8 shadow-xl">
+        {steps.map((step, idx) => (
+          <div key={step.key} className="flex flex-row items-center gap-6">
+            <div
+              className={`flex flex-col items-center justify-center gap-2 ${step.bgClass} rounded-xl p-4 min-w-[110px]`}
+            >
+              <div className="flex items-center justify-center w-12 h-12">
+                {step.icon}
+              </div>
+              <span
+                className={`text-sm font-medium text-center ${step.textClass}`}
+              >
+                {step.label}
+              </span>
+            </div>
+            {idx < arrows.length && (
+              <span className={`text-3xl ${arrows[idx]}`}>→</span>
+            )}
           </div>
-        </div>
-        {/* Arrow */}
-        <span className="text-3xl text-purple-400">→</span>
-        {/* Analysis Agent */}
-        <div className="flex flex-col items-center">
-          <div className="bg-black/60 rounded-xl p-4 flex flex-col items-center shadow-lg relative z-10">
-            <span className="text-4xl mb-2" role="img" aria-label="analysis">
-              <svg width="40" height="40" fill="none" viewBox="0 0 24 24">
-                <rect
-                  width="24"
-                  height="24"
-                  rx="12"
-                  fill="#0ff"
-                  fillOpacity="0.1"
-                />
-                <path
-                  d="M12 6v6m0 0l-3 3m3-3l3 3"
-                  stroke="#0ff"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </span>
-            <span className="text-sm font-semibold text-cyan-300">
-              Analysis Agent
-            </span>
-          </div>
-        </div>
-
-        {/* Arrow */}
-        <span className="text-3xl text-cyan-300">→</span>
-        {/* Writing Agent */}
-        <div className="flex flex-col items-center">
-          <div className="bg-black/60 rounded-xl p-4 flex flex-col items-center shadow-lg">
-            <span className="text-4xl mb-2" role="img" aria-label="writing">
-              <svg width="40" height="40" fill="none" viewBox="0 0 24 24">
-                <rect
-                  width="24"
-                  height="24"
-                  rx="12"
-                  fill="#f0f"
-                  fillOpacity="0.1"
-                />
-                <path
-                  d="M8 16l8-8M8 8h8v8"
-                  stroke="#f0f"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </span>
-            <span className="text-sm font-semibold text-pink-400">
-              Writing Agent
-            </span>
-          </div>
-        </div>
-        {/* Arrow */}
-        <span className="text-3xl text-pink-400">→</span>
-        {/* Expert Content */}
-        <div className="flex flex-col items-center">
-          <div className="bg-black/30 rounded-full p-4 flex flex-col items-center shadow-lg">
-            <span className="text-4xl mb-2" role="img" aria-label="content">
-              <Image
-                src="/file.svg"
-                alt="Expert Content"
-                width={40}
-                height={40}
-                className="mb-2"
-                style={{ filter: "invert(80%)" }}
-              />
-            </span>
-            <span className="text-sm font-semibold text-purple-300">
-              Expert Content
-            </span>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
### ✨ Changes Made:

* All step blocks have **same width, height, padding** (`min-w-[110px]`, `p-4`).
* Icons are **centered in a 48px box** → looks uniform.
* Labels use `text-sm font-medium text-center` (consistent typography).
* Arrows are spaced evenly (`gap-6` between steps).
* Unified step backgrounds (`bg-black/70`) instead of mixed opacities/border-radius.