### PR TITLE
Fix: Resolve ReactNode type error in CrisisCards.tsx

### DIFF
--- a/src/components/sections/content-crisis/CrisisCards.tsx
+++ b/src/components/sections/content-crisis/CrisisCards.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import { FragmentedKnowledgeIcon, ExpertBottlenecksIcon, QualityInconsistencyIcon, TimeIntensiveProcessIcon } from "./CrisisIcons";
 
 interface CrisisCardProps {
-  icon: React.ReactNode;
+  icon: ReactNode;
   title: string;
   description: string;
 }


### PR DESCRIPTION
This commit resolves a type error in `src/components/sections/content-crisis/CrisisCards.tsx` where `React.ReactNode` was used without importing `ReactNode`.

Changes include:
- Added `import type { ReactNode } from "react"` at the top of the file.
- Replaced `React.ReactNode` with `ReactNode` in the `CrisisCardProps` interface.